### PR TITLE
fixed a mistake in get_dL(...) definition in spherical.c

### DIFF
--- a/Geometry/spherical.c
+++ b/Geometry/spherical.c
@@ -1,7 +1,7 @@
 
 #include "../paul.h"
 
-double get_dL( double * xp , double * xm , double dx , int dim ){
+double get_dL( double * xp , double * xm , int dim ){
    double r  = .5*(xp[0]+xm[0]);
    double th = .5*(xp[1]+xm[1]);
    if( dim==0 ) return( xp[0]-xm[0] );


### PR DESCRIPTION
get_dL function is declared and called with 3 arguments (see Hydro/euler_sph.c or Hydro/euler_sph3d.c) but it is defined with 4 in spherical.c. I removed the extra 'double dx' argument in the definition which is not used in the function anyway. This usually compiles without warning (because C...) and does not seem to cause runtime errors because 'dx' is not used in the function and 'dim' is the first and only integer in the parameter list and there is only one integer in the argument list. Nonetheless, this is still technically considered undefined behaviour that should be avoided - perhaps it could cause compile time or run time errors if one is using a different compiler, arch, etc.